### PR TITLE
Hotfix: Ajustes de build para resolução do primeiro tópico do readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/

--- a/Program.cs
+++ b/Program.cs
@@ -33,7 +33,7 @@ namespace TransacaoFinanceira
 
     class executarTransacaoFinanceira : acessoDados
     {
-        public void transferir(int correlation_id, int conta_origem, int conta_destino, decimal valor)
+        public void transferir(int correlation_id, long conta_origem, long conta_destino, decimal valor)
         {
             contas_saldo conta_saldo_origem = getSaldo<contas_saldo>(conta_origem);
             if (conta_saldo_origem.saldo < valor)
@@ -61,17 +61,17 @@ namespace TransacaoFinanceira
     }
     class contas_saldo
     {
-        public contas_saldo(int conta, decimal valor)
+        public contas_saldo(long conta, decimal valor)
         {
             this.conta = conta;
             this.saldo = valor;
         }
-        public int conta { get; set; }
+        public long conta { get; set; }
         public decimal saldo { get; set; }
     }
     class acessoDados
     {
-        Dictionary<int, decimal> SALDOS { get; set; }
+        Dictionary<long, decimal> SALDOS { get; set; }
         private List<contas_saldo> TABELA_SALDOS;
         public acessoDados()
         {
@@ -87,11 +87,11 @@ namespace TransacaoFinanceira
             TABELA_SALDOS.Add(new contas_saldo(563856300, 1200));
 
 
-            SALDOS = new Dictionary<int, decimal>();
+            SALDOS = new Dictionary<long, decimal>();
             this.SALDOS.Add(938485762, 180);
 
         }
-        public T getSaldo<T>(int id)
+        public T getSaldo<T>(long id)
         {
             return (T)Convert.ChangeType(TABELA_SALDOS.Find(x => x.conta == id), typeof(T));
         }

--- a/Program.cs
+++ b/Program.cs
@@ -12,16 +12,16 @@ namespace TransacaoFinanceira
 
         static void Main(string[] args)
         {
-            var TRANSACOES = new[] { new {correlation_id= 1,datetime="09/09/2023 14:15:00", conta_origem= 938485762, conta_destino= 2147483649, VALOR= 150},
-                                     new {correlation_id= 2,datetime="09/09/2023 14:15:05", conta_origem= 2147483649, conta_destino= 210385733, VALOR= 149},
-                                     new {correlation_id= 3,datetime="09/09/2023 14:15:29", conta_origem= 347586970, conta_destino= 238596054, VALOR= 1100},
-                                     new {correlation_id= 4,datetime="09/09/2023 14:17:00", conta_origem= 675869708, conta_destino= 210385733, VALOR= 5300},
-                                     new {correlation_id= 5,datetime="09/09/2023 14:18:00", conta_origem= 238596054, conta_destino= 674038564, VALOR= 1489},
-                                     new {correlation_id= 6,datetime="09/09/2023 14:18:20", conta_origem= 573659065, conta_destino= 563856300, VALOR= 49},
-                                     new {correlation_id= 7,datetime="09/09/2023 14:19:00", conta_origem= 938485762, conta_destino= 2147483649, VALOR= 44},
-                                     new {correlation_id= 8,datetime="09/09/2023 14:19:01", conta_origem= 573659065, conta_destino= 675869708, VALOR= 150},
-
-            };
+            Transacao[] TRANSACOES = [
+                new Transacao { correlation_id = 1, datetime = "09/09/2023 14:15:00", conta_origem = 938485762, conta_destino = 2147483649, VALOR = 150 },
+                new Transacao { correlation_id = 2, datetime = "09/09/2023 14:15:05", conta_origem = 2147483649, conta_destino = 210385733, VALOR = 149 },
+                new Transacao { correlation_id = 3, datetime = "09/09/2023 14:15:29", conta_origem = 347586970, conta_destino = 238596054, VALOR = 1100 },
+                new Transacao { correlation_id = 4, datetime = "09/09/2023 14:17:00", conta_origem = 675869708, conta_destino = 210385733, VALOR = 5300 },
+                new Transacao { correlation_id = 5, datetime = "09/09/2023 14:18:00", conta_origem = 238596054, conta_destino = 674038564, VALOR = 1489 },
+                new Transacao { correlation_id = 6, datetime = "09/09/2023 14:18:20", conta_origem = 573659065, conta_destino = 563856300, VALOR = 49 },
+                new Transacao { correlation_id = 7, datetime = "09/09/2023 14:19:00", conta_origem = 938485762, conta_destino = 2147483649, VALOR = 44 },
+                new Transacao { correlation_id = 8, datetime = "09/09/2023 14:19:01", conta_origem = 573659065, conta_destino = 675869708, VALOR = 150 },
+            ];
             executarTransacaoFinanceira executor = new executarTransacaoFinanceira();
             Parallel.ForEach(TRANSACOES, item =>
             {
@@ -31,11 +31,11 @@ namespace TransacaoFinanceira
         }
     }
 
-    class executarTransacaoFinanceira: acessoDados
+    class executarTransacaoFinanceira : acessoDados
     {
         public void transferir(int correlation_id, int conta_origem, int conta_destino, decimal valor)
         {
-            contas_saldo conta_saldo_origem = getSaldo<contas_saldo>(conta_origem) ;
+            contas_saldo conta_saldo_origem = getSaldo<contas_saldo>(conta_origem);
             if (conta_saldo_origem.saldo < valor)
             {
                 Console.WriteLine("Transacao numero {0 } foi cancelada por falta de saldo", correlation_id);
@@ -49,6 +49,15 @@ namespace TransacaoFinanceira
                 Console.WriteLine("Transacao numero {0} foi efetivada com sucesso! Novos saldos: Conta Origem:{1} | Conta Destino: {3}", correlation_id, conta_saldo_origem.saldo, conta_saldo_destino.saldo);
             }
         }
+    }
+
+    class Transacao
+    {
+        public int correlation_id;
+        public string datetime;
+        public long conta_origem;
+        public long conta_destino;
+        public decimal VALOR;
     }
     class contas_saldo
     {
@@ -80,13 +89,13 @@ namespace TransacaoFinanceira
 
             SALDOS = new Dictionary<int, decimal>();
             this.SALDOS.Add(938485762, 180);
-           
+
         }
         public T getSaldo<T>(int id)
-        {          
+        {
             return (T)Convert.ChangeType(TABELA_SALDOS.Find(x => x.conta == id), typeof(T));
         }
-        public bool atualizar<T>(T  dado)
+        public bool atualizar<T>(T dado)
         {
             try
             {
@@ -100,7 +109,7 @@ namespace TransacaoFinanceira
                 Console.WriteLine(e.Message);
                 return false;
             }
-            
+
         }
 
     }

--- a/Program.cs
+++ b/Program.cs
@@ -38,7 +38,7 @@ namespace TransacaoFinanceira
             contas_saldo conta_saldo_origem = getSaldo<contas_saldo>(conta_origem);
             if (conta_saldo_origem.saldo < valor)
             {
-                Console.WriteLine("Transacao numero {0 } foi cancelada por falta de saldo", correlation_id);
+                Console.WriteLine("Transacao numero {0} foi cancelada por falta de saldo", correlation_id);
 
             }
             else
@@ -46,7 +46,7 @@ namespace TransacaoFinanceira
                 contas_saldo conta_saldo_destino = getSaldo<contas_saldo>(conta_destino);
                 conta_saldo_origem.saldo -= valor;
                 conta_saldo_destino.saldo += valor;
-                Console.WriteLine("Transacao numero {0} foi efetivada com sucesso! Novos saldos: Conta Origem:{1} | Conta Destino: {3}", correlation_id, conta_saldo_origem.saldo, conta_saldo_destino.saldo);
+                Console.WriteLine("Transacao numero {0} foi efetivada com sucesso! Novos saldos: Conta Origem:{1} | Conta Destino: {2}", correlation_id, conta_saldo_origem.saldo, conta_saldo_destino.saldo);
             }
         }
     }

--- a/TransacaoFinanceira.csproj
+++ b/TransacaoFinanceira.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Ajustes para corrigir o primeiro tópico de ajustes do projeto e compilar o projeto:
1. Corrija o que for necessário para resolver os erros de compilação.

Resoluções para compilar:
1. Target Framework: Ajuste de versão do TargetFramework para 8.0 e rodar "dotnet restore" no terminar dentro da pasta root do projeto;
2. Erro de matriz: Criação da classe Transacao e ajuste na inicialização do array, passando como o tipo a nova classe criada;
3. Erro de uint e long: ajuste de tipo int para long nos atributos de conta para aumentar a faixa de valores aceitos;
4. Erro de index no Console.WriteLIne: Ajustar o index interpretado que estava apontando para uma posição inexistente (3) para a posição correta (2).