### PR TITLE
Bugfix: Ajuste de loop de transferência das transações para resolução do segundo tópico do readme

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 
@@ -23,11 +24,12 @@ namespace TransacaoFinanceira
                 new Transacao { correlation_id = 8, datetime = "09/09/2023 14:19:01", conta_origem = 573659065, conta_destino = 675869708, VALOR = 150 },
             ];
             executarTransacaoFinanceira executor = new executarTransacaoFinanceira();
-            Parallel.ForEach(TRANSACOES, item =>
+            foreach (var item in TRANSACOES.OrderBy(x => x.correlation_id))
             {
-                executor.transferir(item.correlation_id, item.conta_origem, item.conta_destino, item.VALOR);
-            });
-
+         
+                    executor.transferir(item.correlation_id, item.conta_origem, item.conta_destino, item.VALOR);
+                
+            };
         }
     }
 
@@ -46,6 +48,9 @@ namespace TransacaoFinanceira
                 contas_saldo conta_saldo_destino = getSaldo<contas_saldo>(conta_destino);
                 conta_saldo_origem.saldo -= valor;
                 conta_saldo_destino.saldo += valor;
+                atualizar(conta_saldo_origem);
+                atualizar(conta_saldo_destino);
+
                 Console.WriteLine("Transacao numero {0} foi efetivada com sucesso! Novos saldos: Conta Origem:{1} | Conta Destino: {2}", correlation_id, conta_saldo_origem.saldo, conta_saldo_destino.saldo);
             }
         }


### PR DESCRIPTION
Ajustes para corrigir o segundo tópico de ajustes do projeto e executar/exibir as transações corretamente ao cliente:

2. Execute o programa para avaliar a saida, identifique e corrija o motivo de algumas transacoes estarem sendo canceladas mesmo com saldo positivo e outras sem saldo sendo efetivadas.

Resoluções para compilar:

1. O Parallel estava processando as transações de forma paralela, sem garantir que a ordem correta de criação fosse respeitada. Isso resultava em inconsistências nos saldos das contas, pois as transações eram aplicadas fora de sequência e as atualizações de saldo não estavam sendo devidamente refletidas. Para corrigir esse comportamento e garantir a consistência dos dados, substituí a execução paralela por um loop foreach, ordenando as transações pelo correlation_id. Dessa forma, assegurei que as transações fossem processadas na ordem correta e os saldos fossem atualizados adequadamente.